### PR TITLE
Prevent pytest from picking up test function as a test

### DIFF
--- a/dendrocat/_astropy_init.py
+++ b/dendrocat/_astropy_init.py
@@ -34,6 +34,7 @@ if not _ASTROPY_SETUP_:  # noqa
     # Create the test function for self test
     from astropy.tests.runner import TestRunner
     test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
+    test.__test__ = False
     __all__ += ['test']
 
     # add these here so we only need to cleanup the namespace at the end


### PR DESCRIPTION
This one-line change prevents pytest from picking up the test function as a test. See astropy/package-template#373.

*This is an automated fix by @pllim. If this is opened in error, please close without merge.*