### PR TITLE
Continued edits, small and large

### DIFF
--- a/dendrocat/radiosource.py
+++ b/dendrocat/radiosource.py
@@ -177,7 +177,8 @@ class RadioSource:
 
     def to_catalog(self, dendrogram=None):
         """
-        Creates a position-position catalog of leaves in a dendrogram.
+        Creates a new position-position catalog of leaves in a dendrogram.
+        This task will overwrite the existing catalog if there is one.
 
         Parameters
         ----------

--- a/dendrocat/radiosource.py
+++ b/dendrocat/radiosource.py
@@ -214,16 +214,15 @@ class RadioSource:
         except KeyError:
             pass
 
-        #This is just wrong, no?  It completely removes the 'rejected' columns
-        # try:
-        #     cat.remove_column('rejected')
-        #     cat.remove_column(self.freq_id+'_detected')
-        # except KeyError:
-        #     pass
+        try:
+            cat.remove_column('rejected')
+            cat.remove_column(self.freq_id+'_detected')
+        except KeyError:
+            pass
 
-        # cat.add_column(Column(np.zeros(len(cat)), dtype=int), name='rejected')
-        # cat.add_column(Column(np.ones(len(cat)), dtype=int),
-        #                name=self.freq_id+'_detected')
+        cat.add_column(Column(np.zeros(len(cat)), dtype=int), name='rejected')
+        cat.add_column(Column(np.ones(len(cat)), dtype=int),
+                       name=self.freq_id+'_detected')
 
         self.catalog = Table(cat, masked=True)
         return Table(cat, masked=True)

--- a/dendrocat/radiosource.py
+++ b/dendrocat/radiosource.py
@@ -497,8 +497,9 @@ class RadioSource:
         return np.array(snr_vals)
 
 
-    def plot_grid(self, catalog=None, data=None, cutouts=None, cutout_data=None,
-                  source_aperture=None, bkg_aperture=None, skip_rejects=True, outfile=None):
+    def plot_grid(self, catalog=None, data=None, cutouts=None,
+                  cutout_data=None, source_aperture=None, bkg_aperture=None,
+                  skip_rejects=True, outfile=None, figurekwargs={}):
         """
         Plot sources in a grid.
 
@@ -596,7 +597,7 @@ class RadioSource:
         xplots = int(np.around(np.sqrt(n_images)))
         yplots = xplots + 1
         gs1 = gs.GridSpec(yplots, xplots, wspace=0.0, hspace=0.0)
-        plt.figure(figsize=(9.5, 10))
+        plt.figure(figsize=(9.5, 10), **figurekwargs)
 
         for i in range(n_images):
 

--- a/dendrocat/radiosource.py
+++ b/dendrocat/radiosource.py
@@ -214,15 +214,16 @@ class RadioSource:
         except KeyError:
             pass
 
-        try:
-            cat.remove_column('rejected')
-            cat.remove_column(self.freq_id+'_detected')
-        except KeyError:
-            pass
+        #This is just wrong, no?  It completely removes the 'rejected' columns
+        # try:
+        #     cat.remove_column('rejected')
+        #     cat.remove_column(self.freq_id+'_detected')
+        # except KeyError:
+        #     pass
 
-        cat.add_column(Column(np.zeros(len(cat)), dtype=int), name='rejected')
-        cat.add_column(Column(np.ones(len(cat)), dtype=int),
-                       name=self.freq_id+'_detected')
+        # cat.add_column(Column(np.zeros(len(cat)), dtype=int), name='rejected')
+        # cat.add_column(Column(np.ones(len(cat)), dtype=int),
+        #                name=self.freq_id+'_detected')
 
         self.catalog = Table(cat, masked=True)
         return Table(cat, masked=True)

--- a/dendrocat/radiosource.py
+++ b/dendrocat/radiosource.py
@@ -451,10 +451,10 @@ class RadioSource:
         """
 
         if catalog is None:
-                try:
-                    catalog = self.catalog
-                except AttributeError:
-                    catalog = self.to_catalog()
+            try:
+                catalog = self.catalog
+            except AttributeError:
+                catalog = self.to_catalog()
 
         # Cascade check
         if source is None or background is None:
@@ -463,9 +463,9 @@ class RadioSource:
                 data = self.data
 
             if cutouts is None or cutout_data is None:
-                size = 2.2*(np.max(catalog['major_fwhm'])*u.deg
-                                    + self.annulus_padding
-                                    + self.annulus_width)
+                #size = 2.2*(np.max(catalog['major_fwhm'])*u.deg
+                #            + self.annulus_padding
+                #            + self.annulus_width)
                 cutouts, cutout_data = self._make_cutouts(catalog=catalog,
                                                           data=data)
 

--- a/dendrocat/utils.py
+++ b/dendrocat/utils.py
@@ -5,6 +5,7 @@ import astropy.units as u
 from astropy.table import MaskedColumn, Column, vstack
 from astropy.coordinates import SkyCoord
 from astropy.utils.console import ProgressBar
+from astropy.stats import mad_std
 from copy import deepcopy
 import warnings
 import regions
@@ -55,11 +56,14 @@ def findrow(idx, catalog):
     idx = int(idx)
     return catalog[np.where(catalog['_idx'] == idx)]
 
-def rms(x):
+def rms(x, mean_abs_dev=False):
     """
     Calculate the root mean squared of some x.
     """
-    return (np.absolute(np.mean(x**2) - (np.mean(x))**2))**0.5
+    if mean_abs_dev:
+        return (np.absolute(np.mean(x**2) - (np.mean(x))**2))**0.5
+    else:
+        return mad_std(x)
 
 def load(infile):
     """

--- a/dendrocat/utils.py
+++ b/dendrocat/utils.py
@@ -1,11 +1,10 @@
 import numpy as np
 from radio_beam import Beams
+from radio_beam.utils import BeamError
 import astropy.units as u
-from astropy.table import MaskedColumn, Column, vstack, Table
+from astropy.table import MaskedColumn, Column, vstack
 from astropy.coordinates import SkyCoord
 from astropy.utils.console import ProgressBar
-import matplotlib.pyplot as plt
-from collections import OrderedDict
 from copy import deepcopy
 import warnings
 import regions
@@ -66,6 +65,7 @@ def load(infile):
     """
     Load a pickle file.
     """
+    import pickle
     filename = infile.split('.')[0]+'.pickle'
     with open(filename, 'rb') as f:
         return pickle.load(f)
@@ -168,7 +168,13 @@ def commonbeam(major1, minor1, pa1, major2, minor2, pa2):
                       [minor1.to(u.arcsec), minor2.to(u.arcsec)]*u.arcsec,
                       [pa1, pa2]*u.deg)
 
-    common = somebeams.common_beam()
+    for tolerance in (1e-4, 5e-5, 1e-5, 1e-6, 1e-7):
+        try:
+            common = somebeams.common_beam(tolerance=tolerance)
+            break
+        except BeamError:
+            continue
+
     new_major = common._major
     new_minor = common._minor
     new_pa = common._pa
@@ -272,8 +278,8 @@ def match(*args, verbose=True, threshold=0.036*u.arcsec):
                                     mask=True)
 
             for j in range(min(10, len(delta_p))):
-                dist_col[j] = np.sqrt(delta_p[j]['x_cen']**2.
-                                      + delta_p[j]['y_cen']**2)
+                dist_col[j] = np.sqrt(delta_p[j]['x_cen']**2. +
+                                      delta_p[j]['y_cen']**2)
                 if dist_col[j] <= threshold:
                     found_match = True
 
@@ -323,4 +329,3 @@ def match(*args, verbose=True, threshold=0.036*u.arcsec):
         stack['_index'] = range(len(stack))
         current_arg = MasterCatalog(arg1, arg2, catalog=stack)
     return current_arg
-


### PR DESCRIPTION
I'm using dendrocat in production now.  I've made a lot of small changes and have a few suggestions.

The `to_{x}` methods have side effects, which is generally undesirable.  A `to_some_other_type()` method should return something, but should not change the underlying object; in `dendrocat`, the `to_catalog` method populates the `radiosource.catalog` with a fresh catalog.  For now, this should be left as is since it's fundamental to how the package is constructed, but for future reference, you should avoid this approach.

I changed the mean-absolute-deviation computation of the RMS to the median absolute deviation based RMS estimator.  It's much more robust and better represents the error.